### PR TITLE
🐛Fix docs light/dark theme switcher

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,13 +8,13 @@ theme:
     primary: deep purple
     accent: amber
     toggle:
-      icon: material/lightbulb-outline
+      icon: material/lightbulb
       name: Switch to dark mode
   - scheme: slate
     primary: deep purple
     accent: amber
     toggle:
-      icon: material/lightbulb
+      icon: material/lightbulb-outline
       name: Switch to light mode
   features:
   - search.suggest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,13 +9,13 @@ theme:
     accent: amber
     toggle:
       icon: material/lightbulb-outline
-      name: Switch to light mode
+      name: Switch to dark mode
   - scheme: slate
     primary: deep purple
     accent: amber
     toggle:
       icon: material/lightbulb
-      name: Switch to dark mode
+      name: Switch to light mode
   features:
   - search.suggest
   - search.highlight


### PR DESCRIPTION
Just a simple fix for the lightbulb's tooltip on the documentation site:

Before:
![image](https://user-images.githubusercontent.com/31937175/130643277-c909d595-2a02-4be7-9e6e-484d9cf98e17.png)
![image](https://user-images.githubusercontent.com/31937175/130643357-3638a7ac-cbfb-4f7b-a698-344121898354.png)

After:
![image](https://user-images.githubusercontent.com/31937175/130643445-c46a938c-ab08-45ba-b4c6-c857cb486831.png)
![image](https://user-images.githubusercontent.com/31937175/130643497-6bd585a3-9e76-4077-ba99-2ccabfb52103.png)

