### PR TITLE
⬆️ Update and relax specification range for `sqlalchemy-stubs`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 python = "^3.6.1"
 SQLAlchemy = ">=1.4.17,<1.5.0"
 pydantic = "^1.8.2"
-sqlalchemy2-stubs = "^0.0.2-alpha.5"
+sqlalchemy2-stubs = {version = "*", allow-prereleases = true}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"


### PR DESCRIPTION
⬆️ Update and relax specification range for `sqlalchemy-stubs` as it's creating conflicts by being alpha, and the extras from SQLAlchemy don't specify a version range either.