### PR TITLE
✏ Fix typos in `docs/tutorial/index.md` and `docs/databases.md`

### DIFF
--- a/docs/databases.md
+++ b/docs/databases.md
@@ -250,7 +250,7 @@ As these **primary key** IDs can uniquely identify each row on the table for tea
 
 <img alt="table relationships" src="/img/databases/relationships.svg">
 
-So, in the table for heroes, we use the `team_id` column to define a relationship to the *foreign* table for teams. Each value in the `team_id` column on the table with heroes will be the same value as the `id` column of one row in the table wiwth teams.
+So, in the table for heroes, we use the `team_id` column to define a relationship to the *foreign* table for teams. Each value in the `team_id` column on the table with heroes will be the same value as the `id` column of one row in the table with teams.
 
 In the table for heroes we have a **primary key** that is the `id`. But we also have another column `team_id` that refers to a **key** in a **foreign** table. There's a technical term for that too, the `team_id` is a "**foreign key**".
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -97,7 +97,7 @@ $ python3 --version
 // This is too old! 😱
 Python 3.5.6
 // Let's see if python3.10 is available
-$ python3.10 --verson
+$ python3.10 --version
 // Oh, no, this one is not available 😔
 command not found: python3.10
 $ python3.9 --version


### PR DESCRIPTION
Fix typo in the tutorial introduction.