### PR TITLE
✏ Fix typos in docs titles

### DIFF
--- a/docs/tutorial/fastapi/limit-and-offset.md
+++ b/docs/tutorial/fastapi/limit-and-offset.md
@@ -1,4 +1,4 @@
-# Read Heroes with Limit and Offset wtih FastAPI
+# Read Heroes with Limit and Offset with FastAPI
 
 When a client sends a request to get all the heroes, we have been returning them all.
 

--- a/docs/tutorial/fastapi/teams.md
+++ b/docs/tutorial/fastapi/teams.md
@@ -1,4 +1,4 @@
-# FastAPI Path Opeartions for Teams - Other Models
+# FastAPI Path Operations for Teams - Other Models
 
 Let's now update the **FastAPI** application to handle data for teams.
 

--- a/docs/tutorial/where.md
+++ b/docs/tutorial/where.md
@@ -204,7 +204,7 @@ We care specially about the **select** statement:
 
 </details>
 
-## Filter Rows Using `WHERE` wtih **SQLModel**
+## Filter Rows Using `WHERE` with **SQLModel**
 
 Now, the same way that we add `WHERE` to a SQL statement to filter rows, we can add a `.where()` to a **SQLModel** `select()` statment to filter rows, which will filter the objects returned:
 


### PR DESCRIPTION
Typos found in section 'FastAPI'. This also impacts the navigation links.

