### PR TITLE
Fix typo within the tutorial

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -97,7 +97,7 @@ $ python3 --version
 // This is too old! 😱
 Python 3.5.6
 // Let's see if python3.10 is available
-$ python3.10 --verson
+$ python3.10 --version
 // Oh, no, this one is not available 😔
 command not found: python3.10
 $ python3.9 --version


### PR DESCRIPTION
Fix a little typo. There was a word misspelled in the tutorial. It said `verson`instead of `version`