### PR TITLE
Fix code typo in limit/offset example with FastAPI

### DIFF
--- a/docs/tutorial/fastapi/limit-and-offset.md
+++ b/docs/tutorial/fastapi/limit-and-offset.md
@@ -42,7 +42,7 @@ We want to allow clients to set a different `offset` and `limit` values.
 
 But we don't want them to be able to set a `limit` of something like `9999`, that's over `9000`! 😱
 
-So, to prevent it, we add additional validation to the `limit` query parameter, declaring that it has to be **l**ess **t**han or **e**qual to `100` with `lte=100`.
+So, to prevent it, we add additional validation to the `limit` query parameter, declaring that it has to be **l**ess than or **e**qual to `100` with `le=100`.
 
 This way, a client can decide to take less heroes if they want, but not more.
 

--- a/docs_src/tutorial/fastapi/limit_and_offset/tutorial001.py
+++ b/docs_src/tutorial/fastapi/limit_and_offset/tutorial001.py
@@ -52,7 +52,7 @@ def create_hero(hero: HeroCreate):
 
 
 @app.get("/heroes/", response_model=List[HeroRead])
-def read_heroes(offset: int = 0, limit: int = Query(default=100, lte=100)):
+def read_heroes(offset: int = 0, limit: int = Query(default=100, le=100)):
     with Session(engine) as session:
         heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
         return heroes


### PR DESCRIPTION
`lte=` in the Query function is not validated by FastAPI, but `le=` is. The code runs fine but if you attempt to set the limit at 9000, FastAPI will not error out.