### PR TITLE
Correct typo in teams.md 

### DIFF
--- a/docs/tutorial/fastapi/teams.md
+++ b/docs/tutorial/fastapi/teams.md
@@ -1,4 +1,4 @@
-# FastAPI Path Opeartions for Teams - Other Models
+# FastAPI Path Operations for Teams - Other Models
 
 Let's now update the **FastAPI** application to handle data for teams.
 


### PR DESCRIPTION
Fixing small typo in teams.md: "Op**ear**tions" to "Op**era**tions"