### PR TITLE
Don't index all fields by default

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -417,7 +417,7 @@ def get_column_from_field(field: ModelField) -> Column:
     nullable = not field.required
     index = getattr(field.field_info, "index", Undefined)
     if index is Undefined:
-        index = True
+        index = False
     if hasattr(field.field_info, "nullable"):
         field_nullable = getattr(field.field_info, "nullable")
         if field_nullable != Undefined:


### PR DESCRIPTION
The code was setting an index on every field by default.
This meant that a simple model like:

```python
class Foo(SQLModel, table=True):
    a: str
    b: int
    c: str
```
Would have indices for all fields. This is wrong, the default should be to not create an index.