### PR TITLE
Allow Field to accept kwargs

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -156,6 +156,7 @@ def Field(
     sa_column_args: Union[Sequence[Any], UndefinedType] = Undefined,
     sa_column_kwargs: Union[Mapping[str, Any], UndefinedType] = Undefined,
     schema_extra: Optional[Dict[str, Any]] = None,
+    **kwargs
 ) -> Any:
     current_schema_extra = schema_extra or {}
     field_info = FieldInfo(
@@ -186,6 +187,7 @@ def Field(
         sa_column_args=sa_column_args,
         sa_column_kwargs=sa_column_kwargs,
         **current_schema_extra,
+        **kwargs
     )
     field_info._validate()
     return field_info


### PR DESCRIPTION
Allow Field function to accept kwargs. Extra key word arguments get passed to the FieldInfo.extra dictionary. This mirrors Pydantic behavior.