### PR TITLE
✏ Fix typo in `docs/db-to-code.md`

### DIFF
--- a/docs/db-to-code.md
+++ b/docs/db-to-code.md
@@ -143,7 +143,7 @@ If the user provides this ID:
 2
 ```
 
-...the  would be this table (with a single row):
+...the result would be this table (with a single row):
 
 <table>
 <tr>


### PR DESCRIPTION
Added a (presumably) missing word in the documentation (db-to-code.md).