### PR TITLE
📝 Add newsletter page

### DIFF
--- a/docs/newsletter.md
+++ b/docs/newsletter.md
@@ -1,0 +1,5 @@
+# FastAPI and friends newsletter
+
+<iframe class="mj-w-res-iframe" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://app.mailjet.com/widget/iframe/6gQ4/GDo" width="100%"></iframe>
+
+<script type="text/javascript" src="https://app.mailjet.com/statics/js/iframeResizer.min.js"></script>


### PR DESCRIPTION
The [help page](https://sqlmodel.tiangolo.com/help/#subscribe-to-the-fastapi-and-friends-newsletter) mentions and has a link to [subscribe to the newsletter](https://sqlmodel.tiangolo.com/newsletter/), but that page is missing from the docs.

Copied it over from FastAPI.