### PR TITLE
🐛 Allow `type_` kwarg in `sa_column_kwargs`

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -444,6 +444,10 @@ def get_column_from_field(field: ModelField) -> Column:
     sa_column_kwargs = getattr(field.field_info, "sa_column_kwargs", Undefined)
     if sa_column_kwargs is not Undefined:
         kwargs.update(cast(dict, sa_column_kwargs))
+
+    if "type_" in kwargs:
+        sa_type = kwargs.pop("type_")
+
     return Column(sa_type, *args, **kwargs)
 
 

--- a/tests/issues/test_74.py
+++ b/tests/issues/test_74.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from sqlalchemy.types import Unicode
+from sqlmodel import Field, Session, SQLModel, create_engine
+
+
+def test_query(clear_sqlmodel):
+    class Hero(SQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        secret_name: str
+        age: Optional[int] = None
+        json_data: str = Field(sa_column_kwargs={"type_": Unicode(20)})
+
+    hero_1 = Hero(
+        name="Deadpond", secret_name="Dive Wilson", json_data=u"{'parody': 'true 😊'}"
+    )
+
+    engine = create_engine("sqlite://")
+
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.add(hero_1)
+        session.commit()
+        session.refresh(hero_1)
+
+    with Session(engine) as session:
+        table = session.query(Hero)._raw_columns[0]
+        query_hero = session.query(Hero).first()
+        assert query_hero
+        assert query_hero.name == hero_1.name
+        assert isinstance(table.columns.json_data.type, Unicode)
+        assert table.columns.json_data.type._expect_unicode
+        assert table.columns.json_data.type.length == len(hero_1.json_data)


### PR DESCRIPTION
In https://github.com/tiangolo/sqlmodel/issues/156 @phi-friday wanted to pass `sa_column_kwargs={"type_": Unicode}` to a `Field` to set the column to `nvarchar`, doing this causes an exception:

```
File "/usr/local/lib/python3.9/site-packages/sqlalchemy/sql/schema.py", line 1586, in __init__
raise exc.ArgumentError(
sqlalchemy.exc.ArgumentError: May not pass type_ positionally and as a keyword.
```

`sa_type` is passed by [get_column_from_field](https://github.com/tiangolo/sqlmodel/blob/02da85c9ec39b0ebb7ff91de3045e0aea28dc998/sqlmodel/main.py#L411) as a positional argument, so passing it through at a kwarg leads to this exception.

PR checks if `type_` is in the kwargs, and if it is it pops it from the kwargs and sets `sa_type` to its value.

Also added a test for this case, @tiangolo is issue-related tests in a separate directory a thing you like? It's not done in FastAPI or here, so if not I'll move it.

----------

Edit: whoops, forgot the `sa_column` argument existed, given that this seems kind of pointless :thinking: 