### PR TITLE
🔧 Split MkDocs insiders build in CI to support building from PRs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -56,7 +56,11 @@ jobs:
           key: mkdocs-cards-${{ github.ref }}
           path: .cache
       - name: Build Docs
+        if: github.event.pull_request.head.repo.fork == true
         run: python -m poetry run mkdocs build
+      - name: Build Docs with Insiders
+        if: github.event.pull_request.head.repo.fork == false
+        run: python -m poetry run mkdocs build --config-file mkdocs.insiders.yml
       - name: Zip docs
         run: python -m poetry run bash ./scripts/zip-docs.sh
       - uses: actions/upload-artifact@v2

--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -1,0 +1,4 @@
+INHERIT: mkdocs.yml
+plugins:
+  - search
+  - social

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,9 +30,6 @@ edit_uri: ''
 google_analytics:
     - UA-205713594-2
     - auto
-plugins:
-- search
-- social
 nav:
   - SQLModel: index.md
   - features.md


### PR DESCRIPTION
🔧 Split MkDocs insiders build in CI to support building from PRs