### PR TITLE
Fix enums converting

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -396,7 +396,7 @@ def get_sqlachemy_type(field: ModelField) -> Any:
     if issubclass(field.type_, time):
         return Time
     if issubclass(field.type_, enum.Enum):
-        return Enum
+        return Enum(field.type_)
     if issubclass(field.type_, bytes):
         return LargeBinary
     if issubclass(field.type_, Decimal):

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -1,9 +1,9 @@
 import ipaddress
 import uuid
 import weakref
+import enum
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from enum import Enum
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -42,6 +42,7 @@ from sqlalchemy import (
     Interval,
     Numeric,
     inspect,
+    Enum
 )
 from sqlalchemy.orm import RelationshipProperty, declared_attr, registry, relationship
 from sqlalchemy.orm.attributes import set_attribute
@@ -394,7 +395,7 @@ def get_sqlachemy_type(field: ModelField) -> Any:
         return Interval
     if issubclass(field.type_, time):
         return Time
-    if issubclass(field.type_, Enum):
+    if issubclass(field.type_, enum.Enum):
         return Enum
     if issubclass(field.type_, bytes):
         return LargeBinary


### PR DESCRIPTION
There was a bug with enums because you return `enum.Enum` instead of `sqlalchemy.Enum` when resolve an enum field