### PR TITLE
🎨 Remove unwanted highlight in the docs

### DIFF
--- a/docs/tutorial/automatic-id-none-refresh.md
+++ b/docs/tutorial/automatic-id-none-refresh.md
@@ -450,7 +450,7 @@ Now let's review all this code once again.
 
     And as we created the **engine** with `echo=True`, we can see the SQL statements being executed at each step.
 
-```{ .python .annotate hl_lines="54" }
+```{ .python .annotate }
 {!./docs_src/tutorial/automatic_id_none_refresh/tutorial002.py!}
 ```
 


### PR DESCRIPTION
There is an unwanted highlight in the [tutorial](https://sqlmodel.tiangolo.com/tutorial/automatic-id-none-refresh/#review-all-the-code) (Or at least it looks like so to me)

ps: I'm loving sqlmodel