### PR TITLE
Add foreign_key name to wrapper

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -369,6 +369,8 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
                     relationship_to, *rel_args, **rel_kwargs
                 )
                 dict_used[rel_name] = rel_value
+                # From https://github.com/tiangolo/sqlmodel/pull/322
+                setattr(cls, rel_name, rel_value)  # Fix #315
             DeclarativeMeta.__init__(cls, classname, bases, dict_used, **kw)
         else:
             ModelMetaclass.__init__(cls, classname, bases, dict_, **kw)

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -440,7 +440,7 @@ def get_column_from_field(
     if foreign_key:
         tablename = getattr(cls, "__tablename__", None)
         if tablename is not None:
-            fk_name = f"{field.name}_{tablename}_fkey"
+            fk_name = f"{tablename}_{field.name}_fkey"
             args.append(ForeignKey(foreign_key, name=fk_name))
         else:
             args.append(ForeignKey(foreign_key))


### PR DESCRIPTION
Due to no name on foreign key objects, Sqlalchemy will complain when trying to drop tables (CircularDependencyError). This PR adds `name` attribute to foreign key objects created by SQLModel.

The error happens inside `sqlalchemy.sql.ddl` module at line 968, e.g., when using Postgres trying to drop tables.