### PR TITLE
🐛 Support mixins

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -323,7 +323,7 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
         # triggers an error
         base_is_table = False
         for base in bases:
-            config = getattr(base, "__config__")
+            config = getattr(base, "__config__", None)
             if config and getattr(config, "table", False):
                 base_is_table = True
                 break

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+import pytest
+from sqlmodel import Field, SQLModel
+
+
+class FooMixin:
+    pass
+
+
+@pytest.mark.usefixtures("clear_sqlmodel")
+def test_mixin():
+    class Hero(FooMixin, SQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        secret_name: str
+        age: Optional[int] = None


### PR DESCRIPTION
Add support for mixins to be used with `SQLModel`. See https://github.com/tiangolo/sqlmodel/issues/254.