### PR TITLE
♻ Refactor internal imports to reduce redundancy

### DIFF
--- a/sqlmodel/sql/sqltypes.py
+++ b/sqlmodel/sql/sqltypes.py
@@ -1,11 +1,10 @@
 import uuid
 from typing import Any, Optional, cast
 
-from sqlalchemy import types
+from sqlalchemy import CHAR, types
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.sql.type_api import TypeEngine
-from sqlalchemy.types import CHAR, TypeDecorator
 
 
 class AutoString(types.TypeDecorator):  # type: ignore
@@ -23,7 +22,7 @@ class AutoString(types.TypeDecorator):  # type: ignore
 
 # Reference form SQLAlchemy docs: https://docs.sqlalchemy.org/en/14/core/custom_types.html#backend-agnostic-guid-type
 # with small modifications
-class GUID(TypeDecorator):  # type: ignore
+class GUID(types.TypeDecorator):  # type: ignore
     """Platform-independent GUID type.
 
     Uses PostgreSQL's UUID type, otherwise uses


### PR DESCRIPTION
There's a redundant import which can be fixed with either of these:

```python
from sqlalchemy import CHAR, types
```

Or:

```python
from sqlalchemy.types import CHAR, TypeDecorator
```