### PR TITLE
Updated tutorial003.py

### DIFF
--- a/docs_src/tutorial/relationship_attributes/back_populates/tutorial003.py
+++ b/docs_src/tutorial/relationship_attributes/back_populates/tutorial003.py
@@ -7,7 +7,7 @@ class Weapon(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(index=True)
 
-    hero: "Hero" = Relationship(back_populates="weapon")
+    owner: "Hero" = Relationship(back_populates="weapon")
 
 
 class Power(SQLModel, table=True):


### PR DESCRIPTION
Looking at the `Hero` Class, it seems that `Relationship` Weapon `back_populates` to `owner`. But in the `Weapon` class, there's no `owner` field, but hero.