### PR TITLE
⬆ Upgrade constrain for SQLAlchemy = ">=1.4.17,<=1.4.41"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6.1"
-SQLAlchemy = ">=1.4.17,<=1.4.35"
+SQLAlchemy = ">=1.4.17,<=1.4.41"
 pydantic = "^1.8.2"
 sqlalchemy2-stubs = {version = "*", allow-prereleases = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6.1"
-SQLAlchemy = ">=1.4.17,<1.5.0"
+SQLAlchemy = ">=1.4.17,<=1.4.35"
 pydantic = "^1.8.2"
 sqlalchemy2-stubs = {version = "*", allow-prereleases = true}
 


### PR DESCRIPTION
SQLAlchemy changes in versions greater than 1.4.35 break relationships and break even the examples in the docs, the latest working version seems to be 1.4.35.

This has been the cause of at least two issues (https://github.com/tiangolo/sqlmodel/issues/255, https://github.com/tiangolo/sqlmodel/issues/315) but probably more.

The breaking change wasn't picked up by dependabot because the current constraint of `<1.5.0` does not register any releases under 1.5.0 as 'new' since the version constraint does not have to be bumped up for it. By limiting it to <**=** dependabot will start bumping up the upper end of the constraints.

PR https://github.com/tiangolo/sqlmodel/pull/322 fixes this with a simple code change but hasn't been merged yet, the constraint range change should still be made so that dependabot will automatically create PRs and run tests on newer versions of SQLAlchemy.