### PR TITLE
♻️ Update `expresion.py`, sync from Jinja2 template, implement `inherit_cache` to solve errors like: `SAWarning: Class SelectOfScalar will not make use of SQL compilation caching`

### DIFF
--- a/scripts/generate_select.py
+++ b/scripts/generate_select.py
@@ -1,3 +1,4 @@
+import os
 from itertools import product
 from pathlib import Path
 from typing import List, Tuple
@@ -51,5 +52,12 @@ result = (
 )
 
 result = black.format_str(result, mode=black.Mode())
+
+current_content = destiny_path.read_text()
+
+if current_content != result and os.getenv("CHECK_JINJA"):
+    raise RuntimeError(
+        "sqlmodel/sql/expression.py content not update with Jinja2 template"
+    )
 
 destiny_path.write_text(result)

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,3 +7,5 @@ mypy sqlmodel
 flake8 sqlmodel tests docs_src
 black sqlmodel tests docs_src --check
 isort sqlmodel tests docs_src scripts --check-only
+# TODO: move this to test.sh after deprecating Python 3.6
+CHECK_JINJA=1 python scripts/generate_select.py

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,7 @@
 set -e
 set -x
 
+CHECK_JINJA=1 python scripts/generate_select.py
 coverage run -m pytest tests
 coverage combine
 coverage report --show-missing

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,7 +3,6 @@
 set -e
 set -x
 
-CHECK_JINJA=1 python scripts/generate_select.py
 coverage run -m pytest tests
 coverage combine
 coverage report --show-missing

--- a/sqlmodel/sql/expression.py
+++ b/sqlmodel/sql/expression.py
@@ -29,14 +29,14 @@ _TSelect = TypeVar("_TSelect")
 if sys.version_info.minor >= 7:
 
     class Select(_Select, Generic[_TSelect]):
-        pass
+        inherit_cache = True
 
     # This is not comparable to sqlalchemy.sql.selectable.ScalarSelect, that has a different
     # purpose. This is the same as a normal SQLAlchemy Select class where there's only one
     # entity, so the result will be converted to a scalar by default. This way writing
     # for loops on the results will feel natural.
     class SelectOfScalar(_Select, Generic[_TSelect]):
-        pass
+        inherit_cache = True
 
 else:
     from typing import GenericMeta  # type: ignore
@@ -45,10 +45,10 @@ else:
         pass
 
     class _Py36Select(_Select, Generic[_TSelect], metaclass=GenericSelectMeta):
-        pass
+        inherit_cache = True
 
     class _Py36SelectOfScalar(_Select, Generic[_TSelect], metaclass=GenericSelectMeta):
-        pass
+        inherit_cache = True
 
     # Cast them for editors to work correctly, from several tricks tried, this works
     # for both VS Code and PyCharm


### PR DESCRIPTION
♻️ Update expresion.py, sync from Jinja2 template.

Also add a test to ensure that the expression.py file is in sync with the Jinja2 template.