### PR TITLE
🔧 Update and add new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
-name: Question
-description: Ask a question
-labels: [question]
+name: Bug
+description: Report a bug
+labels: [bug]
 body:
   - type: markdown
     attributes:
@@ -61,7 +61,7 @@ body:
     attributes:
       label: Example Code
       description: |
-        If applicable, please add a self-contained, [minimal, reproducible, example](https://stackoverflow.com/help/minimal-reproducible-example) with your use case.
+        Please add a self-contained, [minimal, reproducible, example](https://stackoverflow.com/help/minimal-reproducible-example) with your use case.
 
         If I (or someone) can copy it, run it, and see it right away, there's a much higher chance I (or someone) will be able to help you.
 
@@ -92,15 +92,67 @@ body:
             print(hero_1)
       render: python
     validations:
-      required: false
+      required: true
   - type: textarea
     id: description
     attributes:
       label: Description
       description: |
-        What is the question?
+        What is the problem, question, or error?
+
+        Write a short description telling me what you are doing, what you expect to happen, and what is currently happening.
       placeholder: |
-        * How do I have an automatically generated `created_at` field?
+        * Create a Hero model.
+        * Create a Hero instance.
+        * Save it to a SQLite database.
+        * Check the data with DB Browser for SQLite.
+        * There's only one hero there, but I expected it to include many others recruited by the first one.
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you on?
+      multiple: true
+      options:
+        - Linux
+        - Windows
+        - macOS
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: os-details
+    attributes:
+      label: Operating System Details
+      description: You can add more details about your operating system here, in particular if you chose "Other".
+  - type: input
+    id: sqlmodel-version
+    attributes:
+      label: SQLModel Version
+      description: |
+        What SQLModel version are you using?
+
+        You can find the SQLModel version with:
+
+        ```bash
+        python -c "import sqlmodel; print(sqlmodel.__version__)"
+        ```
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      description: |
+        What Python version are you using?
+
+        You can find the Python version with:
+
+        ```bash
+        python --version
+        ```
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,61 @@
+name: Documentation
+description: Suggest changes or request additions to the documentation
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in SQLModel! 🚀
+
+        Please follow these instructions, fill every question, and do every step. 🙏
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: First Check
+      description: Please confirm and check all the following options.
+      options:
+        - label: I added a very descriptive title to this issue.
+          required: true
+        - label: I used the GitHub search to find a similar issue and didn't find it.
+          required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Requested Change
+      description: What kind of change are you requesting?
+      multiple: true
+      options:
+        - Additional Documentation
+        - Clarification
+        - Correction
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: section
+    attributes:
+      label: Documentation Section
+      description: What would the section you're requestion be called/what section requires a correction?
+      placeholder: |
+        https://sqlmodel.tiangolo.com/databases/#what-is-a-database
+        https://github.com/tiangolo/sqlmodel/blob/75ce45588b6a13136916929be4c44946f7e00cbd/docs/databases.md
+        "Databases - What is a Database?"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        What changes would you like to be made to the documentation?
+      placeholder: |
+        * I'd like a page introducing databases, which could describe...
+        * Running the code in section X does not work as described as...
+        * The description in section Y isn't very clear to me because..., could it be clarified?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any additional context information or screenshots you think are useful.


### PR DESCRIPTION
Currently all issues are either a feature request or a question/problem, and they're all labeled either with request or question, which makes it harder to differentiate between potential bug reports and people who just want to ask for help.

This PR changes the templates, splitting them up into:

- "Documentation" (`documentation` label) - requests for clarification/fixes for the docs, as well as requests for new sections
- "Feature Request" (`enhancement`) - not changed from the current template
- "Bug" (`bug`) - reporting a bug, requires code examples
- "Question" (`question`) - questions about usage, similar template to bug but with some fields omitted/no longer mandatory