### PR TITLE
✨ Fully merge Pydantic `Field` with SQLAlchemy `Column` constructor

### DIFF
--- a/tests/test_sa_column.py
+++ b/tests/test_sa_column.py
@@ -1,0 +1,33 @@
+"""These test cases should become obsolete once `sa_column`-parameters are dropped from `Field`."""
+
+import pytest
+from pydantic.config import BaseConfig
+from pydantic.fields import ModelField
+from sqlalchemy.sql.schema import CheckConstraint, Column, ForeignKey
+from sqlmodel.main import Field, FieldInfo, get_column_from_field
+
+
+def test_sa_column_params_raise_warnings():
+    with pytest.warns(DeprecationWarning):
+        Field(sa_column=Column())
+    with pytest.warns(DeprecationWarning):
+        Field(sa_column_args=[ForeignKey("foo.id"), CheckConstraint(">1")])
+    with pytest.warns(DeprecationWarning):
+        Field(sa_column_kwargs={"name": "foo"})
+
+
+def test_sa_column_overrides_other_params():
+    col = Column()
+    field = ModelField(
+        name="foo",
+        type_=str,
+        class_validators=None,
+        model_config=BaseConfig,
+        field_info=FieldInfo(
+            index=True,  # should be ignored
+            sa_column=col,
+        ),
+    )
+    output = get_column_from_field(field)
+    assert output is col
+    assert output.index is None


### PR DESCRIPTION
## Abstract

The proposed changes modify the `Field` constructor to take **all** parameters defined on the SQLAlchemy [`Column`](https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.Column.__init__) directly, instead of just a few.

This makes the parameters `sa_column`, `sa_column_args`, and `sa_column_kwargs` completely **obsolete**!

There is no negative impact on current functionality. All test cases still pass _without_ me modifying them. Test coverage is also not reduced.

## Rationale

The definition of model fields should be **fully in line** with the goals of **SQLModel**, as stated in the documentation.

### Intuitive to write

People coming from an SQLAlchemy background will immediately feel at home with the `Field` constructor, just as people from a Pydantic background already see all the familiar features of it. This honors the project's intent:

> Designed to be easy to use and learn. Less time reading docs.

Until now, leveraging all `Column` features was a little cumbersome and unclear, as evidenced by numerous issues/questions (see below) for trying to figure out how to design all but the most simple database models. The `sa_column`-parameters did allow all that functionality, but sometimes led to unexpected behavior for many people.

### Easy to use

Here are just a few examples of how these changes would make **SQLModel** easier to use.

Defining **custom SQL types** until now _required_ initializing and passing a `Column` instance to `sa_column`. This led to almost all database-related `Field` arguments to be ignored. This is how you had to do it:
```python
class MyModel(SQLModel, table=True):
    custom_field: int = Field(
        sa_column=Column(
            CustomType(impl=Integer()),
            index=True,
        )
    )
```
Whereas now, you can now write this:
```python
class MyModel(SQLModel, table=True):
    custom_field: int = Field(
        type_=CustomType(impl=Integer()),
        index=True,
    )
```
Adding additional **constraints**, defining a different DB **column name**, etc. all _required_ using `sa_column_args`/`sa_column_kwargs` like this:
```python
class AnotherModel(SQLModel, table=True):
    foo: int = Field(
        default=42,
        sa_column_args=[
            CheckConstraint('>0')
        ],
        sa_column_kwargs={
            'name': 'bar',
            'server_onupdate': FetchedValue(),
        }
    )
```
Now you just need to do this:
```python
class AnotherModel(SQLModel, table=True):
    foo: int = Field(
        CheckConstraint('>0'),
        default=42,
        name='bar',
        server_onupdate=FetchedValue(),
    )
```

### Compatible

The package remains just as compatible with FastAPI, Pydantic and SQLAlchemy as before. If anything, allowing to pass _all_ column parameters directly makes that compatibility even more obvious to people coming from SQLAlchemy to **SQLModel**.

### Extensible/Short

see above

## Implementation

<details>
<summary>Details (click me)</summary>

The changes cover basically only three things: The `FieldInfo` class, the `Field` function, and the `get_column_from_field` function. Here are the broad points:

### `class FieldInfo`

- **SQLModel**'s custom `FieldInfo` class (inheriting from the Pydantic one) has been extended to incorporate all the column parameters that have been missing.
- Corresponding `__slots__` were defined mimicking the Pydantic approach.
- Additionally, the attributes were all explicitly type-annotated for easier use "down the line".
- The `__init__` method has been streamlined, but a new helper method `get_defined_column_kwargs` was added which comes into play later to construct a corresponding `Column`.

### `def Field`

- Obviously, this is where the new function parameters have been added to be passed along to the above mentioned `FieldInfo`.
- `DeprecationWarning`s have been added for the `sa_column`-parameters.
- The `default` function parameter has been made _keyword-only_ (like all the rest) and placed _behind_ the newly added variable-length positional arguments `*args`. (This is technically the only backwards incompatible change.) 

### `def get_column_from_field`

- Refactored and extensively commented.
- Constructs the `*args` and `**kwargs` for the `Column` based on the provided field as before, but supporting all possible parameters now.
- Still sets sensible defaults, such as deriving a column type (if it was not provided) based on the field type, and deciding "nullability" based on other field settings.
</details>

## Affected issues (updated 2023-01-04)

- #63 - partially fixed
- #93 - simplified, more intuitive
- #137 - obvious solution
- #178 - partially solved
- #292 - solved
- #298 - simplified, more intuitive
- #314 - fixed
- #319 - obvious solution
- #326 - simplified, more intuitive
- #404 - less verbose solution
- #447 - simplified
- #464 - fixed
- #466 - fixed
- #491 - should be fixed, not sure
- #503 - made irrelevant
- #521 - gets more intuitive solution

A major anticipated benefit of the proposed changes is the reduction of questions about "how to do SQLAlchemy-thing XYZ".

## Affected PRs (updated 2023-01-04)

- #111 - made obsolete
- #158 - made obsolete
- #251 - conflicting, but can be easily combined/rebased
- #366 - arguably made obsolete, since you could directly pass the SQL type like `Field(YourType(**your_kwargs))`, but this is debateable
- #372 - made obsolete, if the `sa_column`-style parameters are dropped/deprecated, as I would suggest
- #505 - made obsolete

It is obviously not my intention to trash other people's work. I respect the effort they put in, just think that those changes are no longer needed/sensible in conjunction with this PR.

## Caveats & arguments against this

<details>
<summary>Details (click me)</summary>

### Huge function signature

The `Field` function's signature will be even larger and perhaps overwhelming for newcomers.

My response would be that a large function signature is not an argument per se, and that **all** arguments remain optional, which allows the actual code to be as concise as possible.

### Commitment to incorporate future additions

Changes/additions to the `Column` parameters in SQLAlchemy in the future would necessitate adjusting the **SQLModel** `Field` function accordingly. Although this is no different from how Pydantic changes already need to be propagated to the custom `Field` constructor, going the route suggested in this PR would require keeping track of both base packages (Pydantic and SQLAlchemy) in the future, to ensure maximum compatibility/familiarity.

I don't think this is such a bad thing, since **SQLModel** aims combine their functionality. If/when SQLAlchemy 2 drops, major changes (maybe even backwards incompatible) may be necessary anyway.

### Possible future parameter conflicts

Parameter names for Pydantic's `Field` and SQLAlchemy's `Column` might conflict in the future.

This is hypothetical and it would not necessarily even cause problems, but if it does, a possible solution would be to distinguish parameters that are completely unrelated with prefixes like `sa_param` and `py_param` or something similar.

### Backwards incompatible `default` parameter

The `default` parameter for the `Field` function is now keyword-only. Until now you can call it like this `Field("a_default_value")`; with the proposed changes, you will _have_ to call it like this `Field(default="a_default_value")`.

This is technically the only backwards incompatible change in this PR. However I have a few arguments for this:
- The documentation so far used the explicit keyword-argument notation _everywhere_ already. This is also why all test cases still pass. Nowhere was a default passed as a positional argument.
- I see no reason for the "preferential treatment" of the `default` parameter in the  `Field` function. This may somewhat make sense with the original Pydantic version of `Field` because there you would normally assign the default value to your model field directly. However, I don't find it intuitive/appropriate at all in the context of **SQLModel** since models are intended to represent database tables and fields represent database columns. The default value for a field/column is just one of many parameters and should not be treated differently. I do concede however that this makes is _slightly_ less familiar to people that come from a Pydantic background, because they may be used to using a positional default.
- This is the only way to reasonably allow using [positional arguments](https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.Column.params.*args) as with SQLAlchemy's Column.
- **SQLModel** is still in its infancy, so 100% backwards compatibility may not even be a requirement yet. This is ultimately for @tiangolo  to decide, of course.
</details>

## Future To-Dos

<details>
<summary>Details (click me)</summary>

- Make it possible to provide the column type as the first positional argument to `Field` as it is with SQLAlchemy `Column`. This should be fairly straight-forward.
- Expand the same logic of dropping the `sa_`-style parameters in favor of full integration to `Relationship` attributes. This may be more difficult; I haven't had the time to look into that.
- Add documentation examples demonstrating that **all** familiar `Column` configurations work the same with **SQLModel** fields.
</details>

---

I hope you will find the time to consider this, @tiangolo. I am looking forward to discussions, counter-arguments, and proposed changes to this from other contributors and am willing to keep working on this.