### PR TITLE
:bug: Fix enum type checks ordering in `get_sqlalchemy_type`

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -372,6 +372,8 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
 
 
 def get_sqlachemy_type(field: ModelField) -> Any:
+    if issubclass(field.type_, Enum):
+        return sa_Enum(field.type_)
     if issubclass(field.type_, str):
         if field.field_info.max_length:
             return AutoString(length=field.field_info.max_length)
@@ -390,8 +392,6 @@ def get_sqlachemy_type(field: ModelField) -> Any:
         return Interval
     if issubclass(field.type_, time):
         return Time
-    if issubclass(field.type_, Enum):
-        return sa_Enum(field.type_)
     if issubclass(field.type_, bytes):
         return LargeBinary
     if issubclass(field.type_, Decimal):


### PR DESCRIPTION
When enum subclassing/mix-in[1] is used, especially to ensure compatibility and produce correct OpenAPI specifications with FastAPI[2], SQLModel on its side doesn't map to the correct SQLAlchemy type.

e.g.:
* `class Foo(Enum)` will work but won't allow a proper OpenAPI spec. to be generated.
* `class Foo(str, Enum)` will fix the previous situation, but prevents SQLModel to read and map the object from the DB (due to validation errors).

Changing ordering of checks to ensure that Enum subclasses are tested first.

[1] https://docs.python.org/3/library/enum.html#restricted-enum-subclassing
[2] https://fastapi.tiangolo.com/sq/tutorial/path-params/#create-an-enum-class