### PR TITLE
🐛 Remove repeated column construction from `SQLModelMetaclass.__init__`

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -325,8 +325,6 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
                 break
         if getattr(cls.__config__, "table", False) and not base_is_table:
             dict_used = dict_.copy()
-            for field_name, field_value in cls.__fields__.items():
-                dict_used[field_name] = get_column_from_field(field_value)
             for rel_name, rel_info in cls.__sqlmodel_relationships__.items():
                 if rel_info.sa_relationship:
                     # There's a SQLAlchemy relationship declared, that takes precedence


### PR DESCRIPTION
## Summary

There was a bug in the `SQLModelMetaclass` whereby the SQLAlchemy `Column` objects were constructed _twice_ for each field defined on a table model: First in the meta class' `__new__` method and then again in its `__init__` method.

With these changes the `get_column_from_field` function is called only _once_ for each field, namely in `SQLModelMetaclass.__new__`.

## Example

Construct a table model with a foreign key explicitly constructed via the SQLAlchemy `ForeignKey` class:
```python
from sqlmodel import Field, SQLModel, create_engine
from sqlalchemy.sql.schema import ForeignKey


class User(SQLModel, table=True):
    id: int = Field(primary_key=True)


class Post(SQLModel, table=True):
    id: int = Field(primary_key=True)
    user_id: int = Field(
        sa_column_args=(ForeignKey("user.id", ondelete="CASCADE"),)
    )
```

Without the proposed changes, even just running these class definitions causes an error:

```
Traceback (most recent call last):
  File "/home/daniil/coding/sqlmodel/experiments/__init__.py", line 12, in <module>
    class Post(SQLModel, table=True):
  File "/home/daniil/coding/sqlmodel/sqlmodel/main.py", line 329, in __init__
    dict_used[field_name] = get_column_from_field(field_value)
  File "/home/daniil/coding/sqlmodel/sqlmodel/main.py", line 457, in get_column_from_field
    return Column(sa_type, *args, **kwargs)  # type: ignore
  File "/home/daniil/.cache/pypoetry/virtualenvs/sqlmodel-TV15XYpK-py3.10/lib/python3.10/site-packages/sqlalchemy/sql/schema.py", line 1765, in __init__
    self._init_items(*args)
  File "/home/daniil/.cache/pypoetry/virtualenvs/sqlmodel-TV15XYpK-py3.10/lib/python3.10/site-packages/sqlalchemy/sql/schema.py", line 144, in _init_items
    spwd(self, **kw)
  File "/home/daniil/.cache/pypoetry/virtualenvs/sqlmodel-TV15XYpK-py3.10/lib/python3.10/site-packages/sqlalchemy/sql/base.py", line 1047, in _set_parent_with_dispatch
    self._set_parent(parent, **kw)
  File "/home/daniil/.cache/pypoetry/virtualenvs/sqlmodel-TV15XYpK-py3.10/lib/python3.10/site-packages/sqlalchemy/sql/schema.py", line 2559, in _set_parent
    raise exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: This ForeignKey already has a parent !
```

This is fixed with this PR.

Add the following to the example:
```python
sqlite_url = "sqlite:///:memory:"
engine = create_engine(sqlite_url, echo=True)
SQLModel.metadata.create_all(engine)
```

There is no more error and the SQL statements are as expected:
```sql
CREATE TABLE user (
	id INTEGER NOT NULL, 
	PRIMARY KEY (id)
)

CREATE TABLE post (
	id INTEGER NOT NULL, 
	user_id INTEGER NOT NULL, 
	PRIMARY KEY (id), 
	FOREIGN KEY(user_id) REFERENCES user (id) ON DELETE CASCADE
)
```