### PR TITLE
🐛 Fix SQLAlchemy version 1.4.36 breaks SQLModel relationships (#315)

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -332,6 +332,7 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
                     # There's a SQLAlchemy relationship declared, that takes precedence
                     # over anything else, use that and continue with the next attribute
                     dict_used[rel_name] = rel_info.sa_relationship
+                    setattr(cls, rel_name, rel_info.sa_relationship)  # Fix #315
                     continue
                 ann = cls.__annotations__[rel_name]
                 temp_field = ModelField.infer(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -94,7 +94,7 @@ def test_should_raise_exception_when_try_to_duplicate_row_if_unique_constraint_i
             session.refresh(hero_2)
 
 
-def test_sa_relationship(clear_sqlmodel):
+def test_sa_relationship_property(clear_sqlmodel):
     """Test https://github.com/tiangolo/sqlmodel/issues/315#issuecomment-1272122306"""
 
     class Team(SQLModel, table=True):
@@ -124,4 +124,5 @@ def test_sa_relationship(clear_sqlmodel):
         session.commit()
         session.refresh(hero_rusty_man)
         # The next statement should not raise an AttributeError
+        assert hero_rusty_man.team
         assert hero_rusty_man.team.name == "Preventers"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -100,7 +100,7 @@ def test_sa_relationship(clear_sqlmodel):
     class Team(SQLModel, table=True):
         id: Optional[int] = Field(default=None, primary_key=True)
         name: str = Field(unique=True)
-        heroes: List["Hero"] = Relationship(
+        heroes: List["Hero"] = Relationship(  # noqa: F821
             sa_relationship=RelationshipProperty("Hero", back_populates="team")
         )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,9 @@
-from typing import Optional
+from typing import List, Optional
 
 import pytest
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import Field, Session, SQLModel, create_engine
+from sqlalchemy.orm import RelationshipProperty
+from sqlmodel import Field, Relationship, Session, SQLModel, create_engine
 
 
 def test_should_allow_duplicate_row_if_unique_constraint_is_not_passed(clear_sqlmodel):
@@ -91,3 +92,36 @@ def test_should_raise_exception_when_try_to_duplicate_row_if_unique_constraint_i
             session.add(hero_2)
             session.commit()
             session.refresh(hero_2)
+
+
+def test_sa_relationship(clear_sqlmodel):
+    """Test https://github.com/tiangolo/sqlmodel/issues/315#issuecomment-1272122306"""
+
+    class Team(SQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str = Field(unique=True)
+        heroes: List["Hero"] = Relationship(
+            sa_relationship=RelationshipProperty("Hero", back_populates="team")
+        )
+
+    class Hero(SQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str = Field(unique=True)
+        team_id: Optional[int] = Field(default=None, foreign_key="team.id")
+        team: Optional[Team] = Relationship(
+            sa_relationship=RelationshipProperty("Team", back_populates="heroes")
+        )
+
+    team_preventers = Team(name="Preventers")
+    hero_rusty_man = Hero(name="Rusty-Man", team=team_preventers)
+
+    engine = create_engine("sqlite://", echo=True)
+
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        session.add(hero_rusty_man)
+        session.commit()
+        session.refresh(hero_rusty_man)
+        # The next statement should not raise an AttributeError
+        assert hero_rusty_man.team.name == "Preventers"


### PR DESCRIPTION
A previous fix was incomplete as it did not cover this use case: https://github.com/tiangolo/sqlmodel/issues/315#issuecomment-1272122306.