### PR TITLE
Add a missing piece to make a foreign key required

### DIFF
--- a/docs/tutorial/relationship-attributes/define-relationships-attributes.md
+++ b/docs/tutorial/relationship-attributes/define-relationships-attributes.md
@@ -115,9 +115,7 @@ This means that this attribute could be `None`, or it could be a full `Team` obj
 
 This is because the related **`team_id` could also be `None`** (or `NULL` in the database).
 
-If it was required for a `Hero` instance to belong to a `Team`, then the `team_id` would be `int` instead of `Optional[int]`.
-
-And the `team` attribute would be a `Team` instead of `Optional[Team]`.
+If it was required for a `Hero` instance to belong to a `Team`, then the `team_id` would be `int` instead of `Optional[int]`, its `Field` would be `Field(foreign_key="team.id")` instead of `Field(default=None, foreign_key="team.id")` and the `team` attribute would be a `Team` instead of `Optional[Team]`.
 
 ## Relationship Attributes With Lists
 


### PR DESCRIPTION
Hi 👋 

I wanted to make a foreign key mandatory and I think that this part of the tutorial was talking about that. I followed those steps but the foreign key wasn't mandatory yet. It didn't show the red "*" in swagger interface and my unit tests were passing without it.

I removed the the default value of the Field object, of the foreign key, and after that, I got the red "*" and my unit tests started to fail.

I'm not sure if this is how it is supposed to be done, but in case it is, here is the PR :)