### PR TITLE
✏️ Fix typo in internal function name `get_sqlachemy_type()`

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -371,7 +371,7 @@ class SQLModelMetaclass(ModelMetaclass, DeclarativeMeta):
             ModelMetaclass.__init__(cls, classname, bases, dict_, **kw)
 
 
-def get_sqlachemy_type(field: ModelField) -> Any:
+def get_sqlalchemy_type(field: ModelField) -> Any:
     if issubclass(field.type_, str):
         if field.field_info.max_length:
             return AutoString(length=field.field_info.max_length)
@@ -418,7 +418,7 @@ def get_column_from_field(field: ModelField) -> Column:  # type: ignore
     sa_column = getattr(field.field_info, "sa_column", Undefined)
     if isinstance(sa_column, Column):
         return sa_column
-    sa_type = get_sqlachemy_type(field)
+    sa_type = get_sqlalchemy_type(field)
     primary_key = getattr(field.field_info, "primary_key", False)
     index = getattr(field.field_info, "index", Undefined)
     if index is Undefined:


### PR DESCRIPTION
The corrected name is get_sqlalchemy_type().