### PR TITLE
Mention StaticPool for in-memory db with FastAPI

### DIFF
--- a/docs/tutorial/fastapi/simple-hero-api.md
+++ b/docs/tutorial/fastapi/simple-hero-api.md
@@ -63,6 +63,9 @@ But here we will make sure we don't share the same **session** in more than one 
 And we also need to disable it because in **FastAPI** each request could be handled by multiple interacting threads.
 
 !!! info
+    If you are using an in-memory SQLite database you should also pass `poolclass=sqlmodel.pool.StaticPool` to the `create_engine()` function since the database exists only within the scope of each connection. The StaticPool implementation will maintain a single connection globally.
+
+!!! info
     That's enough information for now, you can read more about it in the <a href="https://fastapi.tiangolo.com/async/" class="external-link" target="_blank">FastAPI docs for `async` and `await`</a>.
 
     The main point is, by ensuring you **don't share** the same **session** with more than one request, the code is already safe.


### PR DESCRIPTION
> To use a :memory: database in a multithreaded scenario, the same connection object must be shared among threads, since the database exists only within the scope of that connection. The StaticPool implementation will maintain a single connection globally

https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#using-a-memory-database-in-multiple-threads

I think it is important that we mention this here, as anyone trying to learn to use FastAPI/SQLModel will likely start by using an in-memory database. If they are unaware of this detail, they will encounter very confusing bugs which will be near impossible to debug.