### PR TITLE
Fixed limit query parameter name typo

### DIFF
--- a/docs/tutorial/fastapi/limit-and-offset.md
+++ b/docs/tutorial/fastapi/limit-and-offset.md
@@ -42,7 +42,7 @@ We want to allow clients to set different `offset` and `limit` values.
 
 But we don't want them to be able to set a `limit` of something like `9999`, that's over `9000`! 😱
 
-So, to prevent it, we add additional validation to the `limit` query parameter, declaring that it has to be **l**ess **t**han or **e**qual to `100` with `lte=100`.
+So, to prevent it, we add additional validation to the `limit` query parameter, declaring that it has to be **l**ess **t**han or **e**qual to `100` with `le=100`.
 
 This way, a client can decide to take fewer heroes if they want, but not more.
 

--- a/docs_src/tutorial/fastapi/app_testing/tutorial001/main.py
+++ b/docs_src/tutorial/fastapi/app_testing/tutorial001/main.py
@@ -66,7 +66,7 @@ def read_heroes(
     *,
     session: Session = Depends(get_session),
     offset: int = 0,
-    limit: int = Query(default=100, lte=100),
+    limit: int = Query(default=100, le=100),
 ):
     heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
     return heroes

--- a/docs_src/tutorial/fastapi/delete/tutorial001.py
+++ b/docs_src/tutorial/fastapi/delete/tutorial001.py
@@ -58,7 +58,7 @@ def create_hero(hero: HeroCreate):
 
 
 @app.get("/heroes/", response_model=List[HeroRead])
-def read_heroes(offset: int = 0, limit: int = Query(default=100, lte=100)):
+def read_heroes(offset: int = 0, limit: int = Query(default=100, le=100)):
     with Session(engine) as session:
         heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
         return heroes

--- a/docs_src/tutorial/fastapi/limit_and_offset/tutorial001.py
+++ b/docs_src/tutorial/fastapi/limit_and_offset/tutorial001.py
@@ -52,7 +52,7 @@ def create_hero(hero: HeroCreate):
 
 
 @app.get("/heroes/", response_model=List[HeroRead])
-def read_heroes(offset: int = 0, limit: int = Query(default=100, lte=100)):
+def read_heroes(offset: int = 0, limit: int = Query(default=100, le=100)):
     with Session(engine) as session:
         heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
         return heroes

--- a/docs_src/tutorial/fastapi/relationships/tutorial001.py
+++ b/docs_src/tutorial/fastapi/relationships/tutorial001.py
@@ -104,7 +104,7 @@ def read_heroes(
     *,
     session: Session = Depends(get_session),
     offset: int = 0,
-    limit: int = Query(default=100, lte=100),
+    limit: int = Query(default=100, le=100),
 ):
     heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
     return heroes
@@ -159,7 +159,7 @@ def read_teams(
     *,
     session: Session = Depends(get_session),
     offset: int = 0,
-    limit: int = Query(default=100, lte=100),
+    limit: int = Query(default=100, le=100),
 ):
     teams = session.exec(select(Team).offset(offset).limit(limit)).all()
     return teams

--- a/docs_src/tutorial/fastapi/session_with_dependency/tutorial001.py
+++ b/docs_src/tutorial/fastapi/session_with_dependency/tutorial001.py
@@ -66,7 +66,7 @@ def read_heroes(
     *,
     session: Session = Depends(get_session),
     offset: int = 0,
-    limit: int = Query(default=100, lte=100),
+    limit: int = Query(default=100, le=100),
 ):
     heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
     return heroes

--- a/docs_src/tutorial/fastapi/teams/tutorial001.py
+++ b/docs_src/tutorial/fastapi/teams/tutorial001.py
@@ -95,7 +95,7 @@ def read_heroes(
     *,
     session: Session = Depends(get_session),
     offset: int = 0,
-    limit: int = Query(default=100, lte=100),
+    limit: int = Query(default=100, le=100),
 ):
     heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
     return heroes
@@ -150,7 +150,7 @@ def read_teams(
     *,
     session: Session = Depends(get_session),
     offset: int = 0,
-    limit: int = Query(default=100, lte=100),
+    limit: int = Query(default=100, le=100),
 ):
     teams = session.exec(select(Team).offset(offset).limit(limit)).all()
     return teams

--- a/docs_src/tutorial/fastapi/update/tutorial001.py
+++ b/docs_src/tutorial/fastapi/update/tutorial001.py
@@ -58,7 +58,7 @@ def create_hero(hero: HeroCreate):
 
 
 @app.get("/heroes/", response_model=List[HeroRead])
-def read_heroes(offset: int = 0, limit: int = Query(default=100, lte=100)):
+def read_heroes(offset: int = 0, limit: int = Query(default=100, le=100)):
     with Session(engine) as session:
         heroes = session.exec(select(Hero).offset(offset).limit(limit)).all()
         return heroes


### PR DESCRIPTION
Changed Query parameter name from `lte` to `le`.