### PR TITLE
:wrench: fix(type annotation): Add SelectOfScalar to AsyncSession exec statement type annotation

### DIFF
--- a/sqlmodel/ext/asyncio/session.py
+++ b/sqlmodel/ext/asyncio/session.py
@@ -9,7 +9,7 @@ from sqlmodel.sql.base import Executable
 
 from ...engine.result import ScalarResult
 from ...orm.session import Session
-from ...sql.expression import Select
+from ...sql.expression import Select, SelectOfScalar
 
 _T = TypeVar("_T")
 
@@ -42,7 +42,7 @@ class AsyncSession(_AsyncSession):
 
     async def exec(
         self,
-        statement: Union[Select[_T], Executable[_T]],
+        statement: Union[Select[_T], SelectOfScalar[_T], Executable[_T]],
         params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
         execution_options: Mapping[Any, Any] = util.EMPTY_DICT,
         bind_arguments: Optional[Mapping[str, Any]] = None,


### PR DESCRIPTION
Hi, the `statement` argument type annotation of the `exec` method in the `AsyncSession` doesn't include `SelectOfScalar[_T]` causing mypy to complain about using `await session.exec(select(Model))`:
```
error: Argument 1 to "exec" of "AsyncSession" has incompatible type "SelectOfScalar[Model]"; expected "Union[Select[<nothing>], Executable[<nothing>]]"
 ```

Since the synchronous `self.sync_session.exec` [is used under the hood](https://github.com/tiangolo/sqlmodel/blob/43a689d369f52b72aac60efd71111aba7d84714d/sqlmodel/ext/asyncio/session.py#L56), type annotations for the `statement` argument should be the same.