### PR TITLE
📝 Update outdated link in `docs/db-to-code.md`

### DIFF
--- a/docs/db-to-code.md
+++ b/docs/db-to-code.md
@@ -111,7 +111,7 @@ DROP TABLE hero;
 
 That is how you tell the database in SQL to delete the entire table `hero`.
 
-<a href="http://www.nooooooooooooooo.com/" class="external-link" target="_blank">Nooooo!</a> We lost all the data in the `hero` table! 💥😱
+<a href="https://theuselessweb.site/nooooooooooooooo/" class="external-link" target="_blank">Nooooo!</a> We lost all the data in the `hero` table! 💥😱
 
 ### SQL Sanitization
 


### PR DESCRIPTION
I have noticed that clicking the `Nooooo!` in the tutorial on [SQL Injection](https://sqlmodel.tiangolo.com/db-to-code/#sql-injection) fails to load the website. It seems that `www.nooooooooooooooo.com` was taken down. I found a website with a similar image, and propose to update the links.

Alternatively, I guess the link can be removed.