### PR TITLE
Rephrase the documentation to avoid the word "compromise" and use direct language

### DIFF
--- a/docs/tutorial/fastapi/multiple-models.md
+++ b/docs/tutorial/fastapi/multiple-models.md
@@ -57,7 +57,7 @@ But in the responses, we must always send a model from the database, and it must
 
 This means that our application is making the promise to the clients that if it sends a hero, it will for sure have an `id` with a value, it will not be `None`.
 
-### Why Is it Important to have a contract for Responses
+### Why Is it Important to Have a Contract for Responses
 
 The ultimate goal of an API is for some **clients to use it**.
 

--- a/docs/tutorial/fastapi/multiple-models.md
+++ b/docs/tutorial/fastapi/multiple-models.md
@@ -53,17 +53,17 @@ Here's the weird thing, the `id` currently seems also "optional". 🤔
 
 This is because in our **SQLModel** class we declare the `id` with `Optional[int]`, because it could be `None` in memory until we save it in the database and we finally get the actual ID.
 
-But in the responses, we would always send a model from the database, and it would **always have an ID**. So the `id` in the responses could be declared as required too.
+But in the responses, we must always send a model from the database, and it must **always have an ID**. So the `id` in the responses must also be declared as required.
 
-This would mean that our application is making the compromise with the clients that if it sends a hero, it would for sure have an `id` with a value, it would not be `None`.
+This means that our application is making the promise to the clients that if it sends a hero, it will for sure have an `id` with a value, it will not be `None`.
 
-### Why Is it Important to Compromise with the Responses
+### Why Is it Important to have a contract for Responses
 
 The ultimate goal of an API is for some **clients to use it**.
 
 The clients could be a frontend application, a command line program, a graphical user interface, a mobile application, another backend application, etc.
 
-And the code those clients write depends on what our API tells them they **need to send**, and what they can **expect to receive**.
+And the code those clients write depends on what our API tells them they **need to send**, and what they must **expect to receive**.
 
 Making both sides very clear will make it much easier to interact with the API.
 


### PR DESCRIPTION
Changed a few words in the documentation to
1. Use "Have a Contract" instead of "Compromise" as it may be interpreted as "trade-off"
2. Use "must" and "will" instead of "would" to show that it's a commitment