### PR TITLE
⬆️ Support for the latest Pydantic before 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 SQLAlchemy = ">=1.4.36,<2.0.0"
-pydantic = "^1.9.0"
+pydantic = "^1.9.0,<2.0.0"
 sqlalchemy2-stubs = {version = "*", allow-prereleases = true}
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
According to the Roadmap, before we support SQLAlchemy 2.0, we need to first support the latest Pydantic before 2.0.