### PR TITLE
🔇 Do not raise deprecation warnings for execute as it's automatically used internally

### DIFF
--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -95,7 +95,8 @@ class Session(_Session):
         ```Python
         heroes = session.exec(select(Hero)).all()
         ```
-        """
+        """,
+        category=None,
     )
     def execute(  # type: ignore
         self,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import RelationshipProperty
-from sqlmodel import Field, Relationship, Session, SQLModel, create_engine
+from sqlmodel import Field, Relationship, Session, SQLModel, create_engine, select
 
 
 def test_should_allow_duplicate_row_if_unique_constraint_is_not_passed(clear_sqlmodel):
@@ -31,7 +31,7 @@ def test_should_allow_duplicate_row_if_unique_constraint_is_not_passed(clear_sql
         session.refresh(hero_2)
 
     with Session(engine) as session:
-        heroes = session.query(Hero).all()
+        heroes = session.exec(select(Hero)).all()
         assert len(heroes) == 2
         assert heroes[0].name == heroes[1].name
 
@@ -61,7 +61,7 @@ def test_should_allow_duplicate_row_if_unique_constraint_is_false(clear_sqlmodel
         session.refresh(hero_2)
 
     with Session(engine) as session:
-        heroes = session.query(Hero).all()
+        heroes = session.exec(select(Hero)).all()
         assert len(heroes) == 2
         assert heroes[0].name == heroes[1].name
 


### PR DESCRIPTION
🔇 Do not raise deprecation warnings for execute as it's automatically used internally