### PR TITLE
Fix regex argument in Field class (pydantic2)

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -329,6 +329,7 @@ def Field(
         max_length=max_length,
         allow_mutation=allow_mutation,
         regex=regex,
+        pattern=regex,
         discriminator=discriminator,
         repr=repr,
         primary_key=primary_key,

--- a/tests/test_pydantic/test_field.py
+++ b/tests/test_pydantic/test_field.py
@@ -6,6 +6,8 @@ from pydantic import ValidationError
 from sqlmodel import Field, SQLModel
 from typing_extensions import Literal
 
+from ..conftest import needs_pydanticv1, needs_pydanticv2
+
 
 def test_decimal():
     class Model(SQLModel):
@@ -55,3 +57,21 @@ def test_repr():
 
     instance = Model(id=123, foo="bar")
     assert "foo=" not in repr(instance)
+
+
+@needs_pydanticv1
+def test_field_with_regex_kwarg():
+    class Model(SQLModel):
+        pat: str = Field(regex=r"^[a-z]+$")
+
+    with pytest.raises(ValidationError):
+        Model(pat="pydantic1")
+
+
+@needs_pydanticv2
+def test_field_with_regex_kwarg_pydantic2():
+    class Model(SQLModel):
+        pat: str = Field(regex=r"^[a-z]+$")
+
+    with pytest.raises(ValidationError):
+        Model(pat="pydantic2")


### PR DESCRIPTION
Reported here #735 

Version 0.0.14 added support for pydantic v2 (while keeping support for v1).

In this particular case `regex` kwarg to `Field` class is getting silently ignored by pydantic (it is passed through `Field` > `FieldInfo` > `PydanticFieldInfo`) and has no effect.

Here is the most obvious fix which adds `pattern=regex` to `FieldInfo` init. This makes sure that pydantic v2 gets proper argument.

I don't know what is the strategy here about pydantic v1 and v2 and argument names in SQLModel. I can adjust PR if needed.