### PR TITLE
Fix version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqlmodel"
-version = "0"
+version = "0.0.15"
 description = "SQLModel, SQL databases in Python, designed for simplicity, compatibility, and robustness."
 authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Assuming next version is a patch level change, this adds the proper version into pyproject.toml. Without it build on FreeBSD (soon, it will be in packages) breaks.