### PR TITLE
support field max_length

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -18,6 +18,7 @@ from typing import (
     Union,
 )
 
+from annotated_types import MaxLen
 from pydantic import VERSION as PYDANTIC_VERSION
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
@@ -201,6 +202,10 @@ if IS_PYDANTIC_V2:
         for meta in field.metadata:
             if isinstance(meta, PydanticMetadata):
                 return meta
+            elif isinstance(meta, MaxLen):
+                fake = FakeMetadata()
+                fake.max_length = meta.max_length
+                return fake
         return FakeMetadata()
 
     def post_init_field_info(field_info: FieldInfo) -> None:


### PR DESCRIPTION
Currently, when `max_length` is specified in a `Field`, it has no real effect on the corresponding SQL schema (#126, #746). As pointed out by @chris-beedie, this is because the configured `max_length` is stored as an `annotated_types.MaxLen`, rather than a `PydanticMetadata` object, and is therefore ignored in `get_field_metadata`. 

This PR adds a simple extra check for that specific case. I have confirmed it works using PostgreSQL 16.2. 

I also wanted to write a test for it, along the following lines: 

```python
def test_field_max_length_is_enforced(clear_sqlmodel):
    class Hero(SQLModel, table=True):
        id: Optional[int] = Field(default=None, primary_key=True)
        name: str = Field(max_length=5)

    engine = create_engine("sqlite://")

    SQLModel.metadata.create_all(engine)

    with pytest.raises(IntegrityError):
        with Session(engine) as session:
            hero_1 = Hero(name="Deadpond")

            session.add(hero_1)
            session.commit()
            session.refresh(hero_1)
```

Unfortunately, this doesn't work, as `sqlite` [does not actually enforce](https://www.sqlite.org/faq.html#:~:text=SQLite%20does%20not%20enforce%20the,Your%20content%20is%20never%20truncated.) something like `VARCHAR(5)`.

One solution would be to use a `testcontainer` (see [here](https://testcontainers-python.readthedocs.io/en/latest/postgres/README.html)) to run a PostgreSQL instance and test against that, but it would significantly increase the complexity & dependencies of the unit tests. 