### PR TITLE
Add an AwaitableField for accessing sqlmodel field asynchronously

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ httpx = "0.24.1"
 dirty-equals = "^0.6.0"
 typer-cli = "^0.0.13"
 mkdocs-markdownextradata-plugin = ">=0.1.7,<0.3.0"
+pytest-asyncio = "0.21.1"
+aiosqlite = "0.19.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/sqlmodel/ext/asyncio/async_model.py
+++ b/sqlmodel/ext/asyncio/async_model.py
@@ -1,0 +1,69 @@
+from typing import Any, ClassVar, Coroutine, Dict, Tuple, Type
+
+from pydantic._internal._repr import Representation
+from sqlalchemy.util.concurrency import greenlet_spawn
+
+from ... import SQLModel
+from ..._compat import get_annotations
+from ...main import SQLModelMetaclass
+
+
+class AwaitableFieldInfo(Representation):
+    def __init__(self, *, field: str):
+        self.field = field
+
+
+def AwaitableField(*, field: str) -> Any:
+    return AwaitableFieldInfo(field=field)
+
+
+class AsyncSQLModelMetaclass(SQLModelMetaclass):
+    __async_sqlmodel_awaitable_fields__: Dict[str, AwaitableFieldInfo]
+
+    def __new__(
+        cls,
+        name: str,
+        bases: Tuple[Type[Any], ...],
+        class_dict: Dict[str, Any],
+        **kwargs: Any
+    ) -> Any:
+        awaitable_fields: Dict[str, AwaitableFieldInfo] = {}
+        dict_for_sqlmodel = {}
+        original_annotations = get_annotations(class_dict)
+        sqlmodel_annotations = {}
+        awaitable_fields_annotations = {}
+        for k, v in class_dict.items():
+            if isinstance(v, AwaitableFieldInfo):
+                awaitable_fields[k] = v
+            else:
+                dict_for_sqlmodel[k] = v
+        for k, v in original_annotations.items():
+            if k in awaitable_fields:
+                awaitable_fields_annotations[k] = v
+            else:
+                sqlmodel_annotations[k] = v
+
+        dict_used = {
+            **dict_for_sqlmodel,
+            "__async_sqlmodel_awaitable_fields__": awaitable_fields,
+            "__annotations__": sqlmodel_annotations,
+        }
+        return super().__new__(cls, name, bases, dict_used, **kwargs)
+
+    def __init__(
+        cls, classname: str, bases: Tuple[type, ...], dict_: Dict[str, Any], **kw: Any
+    ) -> None:
+        for field_name, field_info in cls.__async_sqlmodel_awaitable_fields__.items():
+
+            def get_awaitable_field(
+                self, field: str = field_info.field
+            ) -> Coroutine[Any, Any, Any]:
+                return greenlet_spawn(getattr, self, field)
+
+            setattr(cls, field_name, property(get_awaitable_field))  # type: ignore
+
+        SQLModelMetaclass.__init__(cls, classname, bases, dict_, **kw)
+
+
+class AsyncSQLModel(SQLModel, metaclass=AsyncSQLModelMetaclass):
+    __async_sqlmodel_awaitable_fields__: ClassVar[Dict[str, AwaitableFieldInfo]]

--- a/sqlmodel/ext/asyncio/async_model.py
+++ b/sqlmodel/ext/asyncio/async_model.py
@@ -25,7 +25,7 @@ class AsyncSQLModelMetaclass(SQLModelMetaclass):
         name: str,
         bases: Tuple[Type[Any], ...],
         class_dict: Dict[str, Any],
-        **kwargs: Any
+        **kwargs: Any,
     ) -> Any:
         awaitable_fields: Dict[str, AwaitableFieldInfo] = {}
         dict_for_sqlmodel = {}

--- a/tests/test_awaitable_field.py
+++ b/tests/test_awaitable_field.py
@@ -1,0 +1,76 @@
+from typing import Awaitable, List, Optional
+
+import pytest
+from sqlalchemy.exc import MissingGreenlet
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.util.concurrency import greenlet_spawn
+
+from sqlmodel import Field, Relationship, SQLModel, select
+from sqlmodel.ext.asyncio.async_model import AsyncSQLModel, AwaitableField
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_awaitable_nomral_field(clear_sqlmodel):
+    class Hero(AsyncSQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+        secret_name: str
+        age: Optional[int] = None
+        awt_name: Awaitable[str] = AwaitableField(field="name")
+        awt_age: Awaitable[str] = AwaitableField(field="age")
+
+    hero_deadpond = Hero(name="Deadpond", secret_name="Dive Wilson")
+
+    engine = create_async_engine("sqlite+aiosqlite://")
+    await greenlet_spawn(SQLModel.metadata.create_all, engine.sync_engine)
+
+    async with AsyncSession(engine) as session:
+        session.add(hero_deadpond)
+        await session.commit()
+
+        # loading expired attribute will raise MissingGreenlet error
+        with pytest.raises(MissingGreenlet):
+            hero_deadpond.name
+
+        name = await hero_deadpond.awt_name
+        assert name == "Deadpond"
+
+
+@pytest.mark.asyncio
+async def test_awaitable_relation_field(clear_sqlmodel):
+    class Team(AsyncSQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str = Field(index=True)
+
+        heroes: List["Hero"] = Relationship()
+        awt_heroes: Awaitable[List["Hero"]] = AwaitableField(field="heroes")
+
+    class Hero(AsyncSQLModel, table=True):
+        id: Optional[int] = Field(default=None, primary_key=True)
+        name: str
+
+        team_id: Optional[int] = Field(default=None, foreign_key="team.id")
+        team: Optional[Team] = Relationship(back_populates="heroes")
+        awt_team: Awaitable[Optional[Team]] = AwaitableField(field="team")
+
+    team_preventers = Team(name="Preventers")
+    hero_rusty_man = Hero(name="Rusty-Man", team=team_preventers)
+
+    engine = create_async_engine("sqlite+aiosqlite://")
+    await greenlet_spawn(SQLModel.metadata.create_all, engine.sync_engine)
+
+    async with AsyncSession(engine) as session:
+        session.add(hero_rusty_man)
+        await session.commit()
+
+    async with AsyncSession(engine) as session:
+        hero = (await session.exec(select(Hero).where(Hero.name == "Rusty-Man"))).one()
+
+        # loading lazy loading attribute will raise MissingGreenlet error
+        with pytest.raises(MissingGreenlet):
+            hero.team
+
+        team = await hero.awt_team
+        assert team
+        assert team.name == "Preventers"

--- a/tests/test_awaitable_field.py
+++ b/tests/test_awaitable_field.py
@@ -4,7 +4,6 @@ import pytest
 from sqlalchemy.exc import MissingGreenlet
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.util.concurrency import greenlet_spawn
-
 from sqlmodel import Field, Relationship, SQLModel, select
 from sqlmodel.ext.asyncio.async_model import AsyncSQLModel, AwaitableField
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -31,7 +30,7 @@ async def test_awaitable_nomral_field(clear_sqlmodel):
 
         # loading expired attribute will raise MissingGreenlet error
         with pytest.raises(MissingGreenlet):
-            hero_deadpond.name
+            hero_deadpond.name  # noqa: B018
 
         name = await hero_deadpond.awt_name
         assert name == "Deadpond"
@@ -69,7 +68,7 @@ async def test_awaitable_relation_field(clear_sqlmodel):
 
         # loading lazy loading attribute will raise MissingGreenlet error
         with pytest.raises(MissingGreenlet):
-            hero.team
+            hero.team  # noqa: B018
 
         team = await hero.awt_team
         assert team


### PR DESCRIPTION
_I'm not that good at English. So, if there's anything you don't understand, please feel free to reply._

Currently, accessing some fields asynchronously is hard. I often encounter the **MissingGreenlet** error while programming asynchronously, which happens because attempting IO without using **await** keyword when accessing lazy loading or expired fields. (others seem to have this problem too #868 #74)

While SQLAlchemy provides the [AsyncAttr](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncAttrs) Mixin, I found it not suitable for sqlmodel because the completion wasn't good enough.

So, I propose an **AwaitableField**, making access to other fields awaitable like below:

## Usage

### Create a AsyncSQLModel and add an awaitable field

You can easliy create a AsyncSQLModel Using the same interface as a sqlmodel. and an AwaitableField yields an awaitable field for the field specified in the argument.

```python
from typing import Optional, Awaitable

from sqlmodel import Field
from sqlmodel.ext.asyncio.async_model import AsyncSQLModel, AwaitableField


class Hero(AsyncSQLModel, table=True):
    id: Optional[int] = Field(default=None, primary_key=True)
    name: str
    awt_name: Awaitable[str] = AwaitableField(field="name")
```

This allows fields which may be subject to lazy loading or deferred / unexpiry loading to be accessed like this:

```
hero = Hero(name="Rusty-Man")
async_session.add(hero)
await async_session.commit()

# the fields of "hero" have expired.
# Therefore, accessing them will raise MissingGreenlet error
print(hero.name)
# E    sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called; 
#      can't call await_only() here. Was IO attempted in an unexpected place? 
#      (Background on this error at: https://sqlalche.me/e/20/xd2s) 

# it works!
print(await hero.awt_name) # Rusty-Man
```

### Access a Relationship Field using an AwaitableField

Using an AwaitableField with Relationship fields can resolve the problem encountered during lazy loading

```python
from typing import Optional, Awaitable

from sqlmodel import Field, select
from sqlmodel.ext.asyncio.async_model import AsyncSQLModel, AwaitableField

class Team(AsyncSQLModel, table=True):
    id: Optional[int] = Field(default=None, primary_key=True)
    heroes: List["Hero"] = Relationship()
    awt_heroes: Awaitable[List["Hero"]] = AwaitableField(field="heroes")


class Hero(AsyncSQLModel, table=True):
    id: Optional[int] = Field(default=None, primary_key=True)
    team_id: Optional[int] = Field(default=None, foreign_key="team.id")
    team: Optional[Team] = Relationship(back_populates="heroes")
    awt_team: Awaitable[Optional[Team]] = AwaitableField(field="team")

...

hero = (
    await session.exec(select(Hero).where(Hero.id == hero_rusty_man.id))
).one()

# loading lazy loading attribute will raise MissingGreenlet error
team = hero.team 
# E    sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called; 
#      can't call await_only() here. Was IO attempted in an unexpected place? 
#      (Background on this error at: https://sqlalche.me/e/20/xd2s) 

# it works!
team = await hero.awt_team
```
