### PR TITLE
📌 Pin typing-extensions in tests for compatiblity with Python 3.8, dirty-equals, Pydantic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         run: pip install --upgrade "pydantic>=1.10.0,<2.0.0"
       - name: Install Pydantic v2
         if: matrix.pydantic-version == 'pydantic-v2'
-        run: pip install --upgrade "pydantic>=2.0.2,<3.0.0"
+        run: pip install --upgrade "pydantic>=2.0.2,<3.0.0" "typing-extensions==4.7.0"
       - name: Lint
         # Do not run on Python 3.7 as mypy behaves differently
         if: matrix.python-version != '3.7' && matrix.pydantic-version == 'pydantic-v2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}-v01
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r requirements-tests.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         run: pip install --upgrade "pydantic>=1.10.0,<2.0.0"
       - name: Install Pydantic v2
         if: matrix.pydantic-version == 'pydantic-v2'
-        run: pip install --upgrade "pydantic>=2.0.2,<3.0.0" "typing-extensions==4.7.0"
+        run: pip install --upgrade "pydantic>=2.0.2,<3.0.0" "typing-extensions==4.6.1"
       - name: Lint
         # Do not run on Python 3.7 as mypy behaves differently
         if: matrix.python-version != '3.7' && matrix.pydantic-version == 'pydantic-v2'

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -12,4 +12,4 @@ dirty-equals ==0.6.0
 jinja2 ==3.1.3
 # Pin typing-extensions until Python 3.8 is deprecated or the issue with dirty-equals
 # is fixed, maybe fixed after dropping Python 3.7 and upgrading dirty-equals
-typing-extensions ==4.7.0
+typing-extensions ==4.6.1

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -12,4 +12,4 @@ dirty-equals ==0.6.0
 jinja2 ==3.1.3
 # Pin typing-extensions until Python 3.8 is deprecated or the issue with dirty-equals
 # is fixed, maybe fixed after dropping Python 3.7 and upgrading dirty-equals
-typing-extensions ==4.11.0
+typing-extensions ==4.7.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -10,3 +10,6 @@ httpx ==0.24.1
 # TODO: upgrade when deprecating Python 3.7
 dirty-equals ==0.6.0
 jinja2 ==3.1.3
+# Pin typing-extensions until Python 3.8 is deprecated or the issue with dirty-equals
+# is fixed, maybe fixed after dropping Python 3.7 and upgrading dirty-equals
+typing-extensions ==4.11.0


### PR DESCRIPTION
👷 Trigger CI without cache to debug Python 3.8 tests