### PR TITLE
Expose pydantic's Field(validation_alias=,serialization_alias=...) parameter

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -153,6 +153,8 @@ class FieldInfo(PydanticFieldInfo):
                 )
         if not hasattr(PydanticFieldInfo, "validation_alias"):
             kwargs.pop("validation_alias")
+        if not hasattr(PydanticFieldInfo, "serialization_alias"):
+            kwargs.pop("serialization_alias")
         super().__init__(default=default, **kwargs)
         self.primary_key = primary_key
         self.nullable = nullable
@@ -278,6 +280,7 @@ def Field(
     default_factory: Optional[NoArgAnyCallable] = None,
     alias: Optional[str] = None,
     validation_alias: Optional[str] = None,
+    serialization_alias: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     exclude: Union[
@@ -320,6 +323,7 @@ def Field(
         default_factory=default_factory,
         alias=alias,
         validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
         title=title,
         description=description,
         exclude=exclude,

--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -201,6 +201,8 @@ def Field(
     *,
     default_factory: Optional[NoArgAnyCallable] = None,
     alias: Optional[str] = None,
+    validation_alias: Optional[str] = None,
+    serialization_alias: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     exclude: Union[
@@ -244,6 +246,8 @@ def Field(
     *,
     default_factory: Optional[NoArgAnyCallable] = None,
     alias: Optional[str] = None,
+    validation_alias: Optional[str] = None,
+    serialization_alias: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
     exclude: Union[


### PR DESCRIPTION
This expands upon and closes PR #774 by adding serialization_alias and missing Field override parameters.

Allows for serializing json using serialization_alias when by_alias is true
```object.model_dump_json(by_alias=True)```