### PR TITLE
✏️ Fix pydantic invalid when table=True(#1036)

### DIFF
--- a/sqlmodel/_compat.py
+++ b/sqlmodel/_compat.py
@@ -346,6 +346,16 @@ if IS_PYDANTIC_V2:
                 self_instance=self,
             )
         else:
+            raw_self = self.model_copy()
+            pydantic_validated_model = self.__pydantic_validator__.validate_python(
+                data,
+                self_instance=raw_self,
+            )
+            pydantic_dict = pydantic_validated_model.model_dump()
+            for k in pydantic_dict.keys():
+                if k not in data.keys():
+                    continue
+                data[k] = pydantic_dict[k]
             sqlmodel_table_construct(
                 self_instance=self,
                 values=data,

--- a/tests/test_instance_no_args.py
+++ b/tests/test_instance_no_args.py
@@ -2,27 +2,7 @@ from typing import Optional
 
 import pytest
 from pydantic import ValidationError
-from sqlmodel import Field, Session, SQLModel, create_engine, select
-
-
-def test_allow_instantiation_without_arguments(clear_sqlmodel):
-    class Item(SQLModel, table=True):
-        id: Optional[int] = Field(default=None, primary_key=True)
-        name: str
-        description: Optional[str] = None
-
-    engine = create_engine("sqlite:///:memory:")
-    SQLModel.metadata.create_all(engine)
-    with Session(engine) as db:
-        item = Item()
-        item.name = "Rick"
-        db.add(item)
-        db.commit()
-        statement = select(Item)
-        result = db.exec(statement).all()
-    assert len(result) == 1
-    assert isinstance(item.id, int)
-    SQLModel.metadata.clear()
+from sqlmodel import Field, SQLModel
 
 
 def test_not_allow_instantiation_without_arguments_if_not_table():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pytest
 from pydantic.error_wrappers import ValidationError
-from sqlmodel import SQLModel
+from sqlmodel import Field, SQLModel
 
 from .conftest import needs_pydanticv1, needs_pydanticv2
 
@@ -63,3 +63,34 @@ def test_validation_pydantic_v2(clear_sqlmodel):
 
     with pytest.raises(ValidationError):
         Hero.model_validate({"name": None, "age": 25})
+
+
+@needs_pydanticv2
+def test_validation_with_table_true():
+    """Test validation with table=True."""
+    from pydantic import field_validator
+
+    class Hero(SQLModel, table=True):
+        name: Optional[str] = Field(default=None, primary_key=True)
+        secret_name: Optional[str] = None
+        age: Optional[int] = None
+
+        @field_validator("age", mode="after")
+        @classmethod
+        def double_age(cls, v):
+            if v is not None:
+                return v * 2
+            return v
+
+    Hero(name="Deadpond", age=25)
+    Hero.model_validate({"name": "Deadpond", "age": 25})
+    with pytest.raises(ValidationError):
+        Hero(name="Deadpond", secret_name="Dive Wilson", age="test")
+    with pytest.raises(ValidationError):
+        Hero.model_validate({"name": "Deadpond", "age": "test"})
+
+    double_age_hero = Hero(name="Deadpond", age=25)
+    assert double_age_hero.age == 50
+
+    double_age_hero = Hero.model_validate({"name": "Deadpond", "age": 25})
+    assert double_age_hero.age == 50


### PR DESCRIPTION
I found that when `table=True` is set, pydantic becomes invalid for usage like `hero = Hero(name="Deadpond", secret_name="Dive Wilson", age="test")`. As [the document](https://sqlmodel.tiangolo.com/features/#based-on-pydantic) says `you get all of Pydantic's features, including automatic data validation, serialization, and documentation. You can use SQLModel in the same way you can use Pydantic.`, I think `table=True` makes pydantic invalid is a bug, so I tried to fix it.

I delete a test case because this case is incompatible with pydantic. I also add a test case to ensure my code works. For current code, my new test case would fail, but it would pass for my new code. 