### PR TITLE
📝 Fix broken links in docs

### DIFF
--- a/docs/tutorial/create-db-and-table-with-db-browser.md
+++ b/docs/tutorial/create-db-and-table-with-db-browser.md
@@ -40,7 +40,7 @@ Click the button <kbd>New Database</kbd>.
 
 <img class="shadow" src="/img/create-db-and-table-with-db-browser/image001.png">
 
-A dialog should show up. Go to the [project directory you created](./index.md#create-a-project){.internal-link target=_blank} and save the file with a name of `database.db`.
+A dialog should show up. Go to the [project directory you created](../virtual-environments.md#create-a-project){.internal-link target=_blank} and save the file with a name of `database.db`.
 
 /// tip
 

--- a/docs/tutorial/create-db-and-table.md
+++ b/docs/tutorial/create-db-and-table.md
@@ -2,7 +2,7 @@
 
 Now let's get to the code. 👩‍💻
 
-Make sure you are inside of your project directory and with your virtual environment activated as [explained in the previous chapter](index.md){.internal-link target=_blank}.
+Make sure you are inside of your project directory and with your virtual environment activated as explained in [Virtual Environments](../virtual-environments.md#create-a-project){.internal-link target=_blank}.
 
 We will:
 
@@ -327,7 +327,7 @@ Put the code it in a file `app.py` if you haven't already.
 
 /// tip
 
-Remember to [activate the virtual environment](./index.md#create-a-python-virtual-environment){.internal-link target=_blank} before running it.
+Remember to [activate the virtual environment](../virtual-environments.md#create-a-virtual-environment){.internal-link target=_blank} before running it.
 
 ///
 


### PR DESCRIPTION
Currently on `main` we have 2 broken links in docs:

```
INFO    -  Doc file 'tutorial/create-db-and-table-with-db-browser.md' contains a link './index.md#create-a-project', but the doc 'tutorial/index.md' does not contain an anchor '#create-a-project'.
INFO    -  Doc file 'tutorial/create-db-and-table.md' contains a link './index.md#create-a-python-virtual-environment', but the doc 'tutorial/index.md' does not contain an anchor '#create-a-python-virtual-environment'.
```

https://github.com/fastapi/sqlmodel/actions/runs/18385627235/job/52383213256#step:10:22