### PR TITLE
✅ Remove unused type ignores since SQLAlchemy 2.0.44

### DIFF
--- a/sqlmodel/ext/asyncio/session.py
+++ b/sqlmodel/ext/asyncio/session.py
@@ -129,7 +129,7 @@ class AsyncSession(_AsyncSession):
         ```
         """
     )
-    async def execute(  # type: ignore
+    async def execute(
         self,
         statement: _Executable,
         params: Optional[_CoreAnyExecuteParams] = None,

--- a/sqlmodel/orm/session.py
+++ b/sqlmodel/orm/session.py
@@ -113,7 +113,7 @@ class Session(_Session):
         """,
         category=None,
     )
-    def execute(  # type: ignore
+    def execute(
         self,
         statement: _Executable,
         params: Optional[_CoreAnyExecuteParams] = None,


### PR DESCRIPTION
Since SQLAlchemy 2.0.44, we can remove two unnecessary `type: ignore` statements. If we don't remove them, `mypy` will fail our CI with
```
sqlmodel/orm/session.py:116: error: Unused "type: ignore" comment  [unused-ignore]
sqlmodel/ext/asyncio/session.py:132: error: Unused "type: ignore" comment  [unused-ignore]
Found 2 errors in 2 files
```